### PR TITLE
Fix exception in completions

### DIFF
--- a/completions/types.py
+++ b/completions/types.py
@@ -577,7 +577,7 @@ quote = [
     ("no-open-quote",),
     ("open-quote",),
 ]
-ratio = [("<ratio>", "${1}/${2}")]
+ratio = ("<ratio>", "${1}/${2}")
 repeat_style = [
     ("no-repeat",),
     ("repeat",),


### PR DESCRIPTION
Resolve #129 

The `ratio` type in `types.py` was being incorrectly used in `properties.py`.
This caused an exception that broke completions :(

Thank you to @FeBe95 for the prompt report! 🙏 