### PR TITLE
Reenable styling of inline CSS

### DIFF
--- a/CSS3.sublime-syntax
+++ b/CSS3.sublime-syntax
@@ -10448,6 +10448,7 @@ contexts:
         - meta_scope: meta.declaration-list.css
         - match: $|(?![-a-z])
           pop: true
+        - include: properties
 
   selector:
     # This match applies a single meta.selector.css scope to a comma-separated


### PR DESCRIPTION
Resolve #131 

I disabled inline styling because #107 was causing widespread pain. CSS3 has so many syntax highlighting contexts that it was exceeding a hard limit of 25,000 contexts set by Sublime. This caused breakages of HTML, PHP, and any other language that embeds the HTML syntax (which embeds source.css).

I made several failed attempts to fix this issue before finally giving up and disabling inline styling. Then, the issue magically went away somewhere around Sublime build 3209. I can't reproduce #107 anymore, so I'm going to try reenabling inline styling🤞😬