### PR TITLE
Disable highlighting of inline CSS

### DIFF
--- a/CSS3.sublime-syntax
+++ b/CSS3.sublime-syntax
@@ -10448,7 +10448,8 @@ contexts:
         - meta_scope: meta.declaration-list.css
         - match: $|(?![-a-z])
           pop: true
-        - include: properties
+        # We have to disable this because it causes #107 (exceeded 25000 context stack limit).
+        # - include: properties
 
   selector:
     # This match applies a single meta.selector.css scope to a comma-separated


### PR DESCRIPTION
I thought the #107 issue was fixed (exceed 25000 context stack limit), but [apparently it's not](https://github.com/ryboe/CSS3/issues/131#issuecomment-642894694). This commit disables it again.