### PR TITLE
Fix block- and inline-size not highlighted

### DIFF
--- a/CSS3.sublime-syntax
+++ b/CSS3.sublime-syntax
@@ -4541,7 +4541,7 @@ contexts:
 
   # CSS Logical Properties and Values Level 1
   property-block-inline-size:
-    - match: '{{optional_min_max_prefix}}(?:block-size|inline-size)\s*(:)'
+    - match: '{{optional_min_max_prefix}}(block-size|inline-size)\s*(:)'
       captures:
         1: support.constant.property-name.css
         2: punctuation.separator.key-value.css


### PR DESCRIPTION
The regex for the `block-size` and `inline-size` property names mistakenly didn't capture the 'block-size' or 'inline-size' text. Therefore, the `support.constant.property-name.css` context was never applied to the text and it wasn't highlighted. Thanks very much to @argyleink for [reporting the issue](https://github.com/ryboe/CSS3/pull/143#issuecomment-783757325) 🙏 