### PR TITLE
Update README instructions for disabling Emmet completions

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,10 +71,10 @@ The most complete CSS and PostCSS-cssnext support for Sublime Text.
 
     If you have Emmet installed, its completions will drown out the
     carefully researched, standards-based completions offered by this package.
-    You can hide Emmet completions without disabling them by adding this line to
+    You can hide Emmet completions for CSS only by adding this line to
     your Emmet package settings.
     ```json
-    "show_css_completions": false
+    "abbreviation_preview": "markup"
     ```
 
 6. (Recommended) Set CSS3 as the default language for `.css` files


### PR DESCRIPTION
Resolve #161.

The Emmet plugin was rewritten in v2. The old config setting for disabling Emmet's CSS3 completions doesn't work anymore. The new setting is `"abbreviation_preview": "markup"`, which [disables Emmet's CSS completions, but keeps them for markup languages like HTML, XML, and JSX](https://github.com/emmetio/sublime-text-plugin#css-support).

