### PR TITLE
Remove menu tag from deprecated list

### DIFF
--- a/CSS3.sublime-syntax
+++ b/CSS3.sublime-syntax
@@ -11280,7 +11280,6 @@ contexts:
           nextid|
           multicol|
           menuitem|
-          menu|
           marquee|
           listing|
           keygen|


### PR DESCRIPTION
Related issue: https://github.com/ryboe/CSS3/issues/181

Removes `menu` from the deprecated list.

As mentioned [on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/menu), the `menu` element was, at some point, used for context menus; that functionality has been deprecated, but the `menu` element has been given a new meaning and therefore should not be marked as deprecated.