### PR TITLE
Add syntax definitions for container at rule

### DIFF
--- a/CSS3.sublime-syntax
+++ b/CSS3.sublime-syntax
@@ -437,6 +437,48 @@ contexts:
   # |-------------------outer scope-----------------------------------|
   #        |---media-features-etc----||--------nested scope----------|
   # @media stuff-before-opening-curly { selector { property: value; } }
+  at-container:
+    - match: '(@)container{{b}}'
+      captures:
+        0: keyword.control.at-rule.container.css
+        1: punctuation.definition.keyword.css
+      push:
+        - meta_scope: meta.at-rule.container.css
+        - match: '}'
+          scope: punctuation.section.at-container.end.css
+          pop: true
+        - match: '{'
+          scope: punctuation.section.at-container.begin.css
+          push:
+            - meta_scope: meta.at-rule.container.block.css
+            - match: '(?=})'
+              pop: true
+            - include: nestable-at-rules
+            - include: properties
+            - include: rule
+        - include: container-query-list
+
+  at-layer:
+    - match: '(@)layer{{b}}'
+      captures:
+        0: keyword.control.at-rule.layer.css
+        1: punctuation.definition.keyword.css
+      push:
+        - meta_scope: meta.at-rule.media.css
+        - match: '}'
+          scope: punctuation.section.at-media.end.css
+          pop: true
+        - match: '{'
+          scope: punctuation.section.at-media.begin.css
+          push:
+            - meta_scope: meta.at-rule.media.block.css
+            - match: '(?=})'
+              pop: true
+            - include: nestable-at-rules
+            - include: properties
+            - include: rule
+    - include: stray-brace
+
   at-media:
     - match: '(@)media{{b}}'
       captures:
@@ -457,27 +499,6 @@ contexts:
             - include: properties
             - include: rule
         - include: media-query-list
-    - include: stray-brace
-
-  at-layer:
-    - match: '(@)layer{{b}}'
-      captures:
-        0: keyword.control.at-rule.media.css
-        1: punctuation.definition.keyword.css
-      push:
-        - meta_scope: meta.at-rule.media.css
-        - match: '}'
-          scope: punctuation.section.at-media.end.css
-          pop: true
-        - match: '{'
-          scope: punctuation.section.at-media.begin.css
-          push:
-            - meta_scope: meta.at-rule.media.block.css
-            - match: '(?=})'
-              pop: true
-            - include: nestable-at-rules
-            - include: properties
-            - include: rule
     - include: stray-brace
 
   at-namespace:
@@ -982,7 +1003,11 @@ contexts:
         - meta_scope: meta.declaration-list.css
         - match: '(?=})'
           pop: true
+<<<<<<< HEAD
         - match: '(?=@media|@supports|@layer)|(?=[\w.:#\[*-&][^;}]*\{)'
+=======
+        - match: '(?=@nest|@media|@supports|@layer|@container|&)'
+>>>>>>> 7765fa8 (Add syntax definitions for @container at-rule)
           push:
             - match: '(?=})'
               scope: punctuation.section.declaration-list.end.css
@@ -3496,6 +3521,12 @@ contexts:
         - include: length-non-negative
         - include: media-feature-range-operator
 
+  container-query-list:
+    - match: '\band{{b}}'
+      scope: keyword.operator.logic.media.css
+    - include: media-feature
+    - include: identifier
+
   # This is used by the at-media and at-import contexts.
   media-query-list:
     - match: '\band{{b}}'
@@ -3515,6 +3546,7 @@ contexts:
       scope: support.constant.media.css invalid.deprecated.css
 
   nestable-at-rules:
+    - include: at-container
     - include: at-font-feature-values
     - include: at-font-palette-values
     - include: at-counter-style

--- a/CSS3.sublime-syntax
+++ b/CSS3.sublime-syntax
@@ -1003,11 +1003,7 @@ contexts:
         - meta_scope: meta.declaration-list.css
         - match: '(?=})'
           pop: true
-<<<<<<< HEAD
-        - match: '(?=@media|@supports|@layer)|(?=[\w.:#\[*-&][^;}]*\{)'
-=======
-        - match: '(?=@nest|@media|@supports|@layer|@container|&)'
->>>>>>> 7765fa8 (Add syntax definitions for @container at-rule)
+        - match: '(?=@media|@supports|@layer|@container)|(?=[\w.:#\[*-&][^;}]*\{)'
           push:
             - match: '(?=})'
               scope: punctuation.section.declaration-list.end.css

--- a/CSS3.sublime-syntax
+++ b/CSS3.sublime-syntax
@@ -458,27 +458,6 @@ contexts:
             - include: rule
         - include: container-query-list
 
-  at-layer:
-    - match: '(@)layer{{b}}'
-      captures:
-        0: keyword.control.at-rule.layer.css
-        1: punctuation.definition.keyword.css
-      push:
-        - meta_scope: meta.at-rule.media.css
-        - match: '}'
-          scope: punctuation.section.at-media.end.css
-          pop: true
-        - match: '{'
-          scope: punctuation.section.at-media.begin.css
-          push:
-            - meta_scope: meta.at-rule.media.block.css
-            - match: '(?=})'
-              pop: true
-            - include: nestable-at-rules
-            - include: properties
-            - include: rule
-    - include: stray-brace
-
   at-media:
     - match: '(@)media{{b}}'
       captures:
@@ -499,6 +478,27 @@ contexts:
             - include: properties
             - include: rule
         - include: media-query-list
+    - include: stray-brace
+
+  at-layer:
+    - match: '(@)layer{{b}}'
+      captures:
+        0: keyword.control.at-rule.media.css
+        1: punctuation.definition.keyword.css
+      push:
+        - meta_scope: meta.at-rule.media.css
+        - match: '}'
+          scope: punctuation.section.at-media.end.css
+          pop: true
+        - match: '{'
+          scope: punctuation.section.at-media.begin.css
+          push:
+            - meta_scope: meta.at-rule.media.block.css
+            - match: '(?=})'
+              pop: true
+            - include: nestable-at-rules
+            - include: properties
+            - include: rule
     - include: stray-brace
 
   at-namespace:

--- a/completions/at_rules.py
+++ b/completions/at_rules.py
@@ -11,6 +11,7 @@ font_feature_types = [
 namespace_values = [t.identifier, t.string, t.url]
 nestable = [
     # @-rules that can appear inside other @-rules.
+    ("@container", "@container ${1} {\n\t${2}\n}"),
     ("@counter-style", "@counter-style ${1:name} {\n\t${2}\n}"),
     ("@font-face", "@font-face {\n\t${1}\n}"),
     ("@font-feature-values", "@font-feature-values ${1:font-family} {\n\t${2}\n}"),


### PR DESCRIPTION
Related issue: https://github.com/ryboe/CSS3/issues/184

Adds support for `@container`.

Container queries are a _tiny_ bit different from `@media` in syntax, since container queries allow an identifier (the container name) and not media-specific keyword (such as `screen` or `print`).