### PR TITLE
Fix syntax for font shorthand

### DIFF
--- a/CSS3.sublime-syntax
+++ b/CSS3.sublime-syntax
@@ -6397,8 +6397,6 @@ contexts:
         - meta_content_scope: meta.property-value.font.css
         - include: end-value
         - include: value-css-wide
-        - include: font-family-generic
-        - include: font-family-name
         - match: '(?x)
             \b
             (?:
@@ -6439,6 +6437,8 @@ contexts:
         - include: percentage-non-negative
         - include: length-non-negative
         - include: number-non-negative
+        - include: font-family-generic
+        - include: font-family-name
     - include: stray-paren-or-semicolon
 
   # CSS Fonts Module Level 4

--- a/CSS3.sublime-syntax
+++ b/CSS3.sublime-syntax
@@ -6437,6 +6437,8 @@ contexts:
         - include: percentage-non-negative
         - include: length-non-negative
         - include: number-non-negative
+        - match: '\/'
+          scope: keyword.operator.arithmetic.css
         - include: font-family-generic
         - include: font-family-name
     - include: stray-paren-or-semicolon


### PR DESCRIPTION
Related issue: https://github.com/ryboe/CSS3/issues/181

Fixes the `font` shorthand. `font-family-name` was just eating all of the tokens as if they were identifiers, so simply reordering the includes fixes the issue.