### PR TITLE
Add repeat to valid value for grid template

### DIFF
--- a/CSS3.sublime-syntax
+++ b/CSS3.sublime-syntax
@@ -6982,6 +6982,9 @@ contexts:
         - include: track-size
         - include: line-names
         - include: fixed-size
+        - include: fixed-repeat
+        - match: '\/'
+          scope: keyword.operator.arithmetic.css
     - include: stray-paren-or-semicolon
 
   # grid-template-areas is defined in two specs:

--- a/CSS3.sublime-syntax
+++ b/CSS3.sublime-syntax
@@ -6904,6 +6904,8 @@ contexts:
         - include: end-value
         - include: value-css-wide
         - include: string
+        - match: '\/'
+          scope: keyword.operator.arithmetic.css
         - match: '\b(?:subgrid|none|dense|auto-flow){{b}}'
           scope: support.constant.property-value.css
         - include: track-list

--- a/test/property-list.css
+++ b/test/property-list.css
@@ -3539,6 +3539,7 @@
     grid: inherit;
     grid: unset;
     grid: 10rem 10rem 10rem 10rem / 1fr 1fr 1fr 1fr;
+    grid: repeat(4, 10rem) / repeat(4, 1fr);
     grid: 12rem 12rem 12rem 12rem / 10rem 10rem 10rem 10rem;
     -webkit-grid: 12rem 12rem 12rem 12rem / 10rem 10rem 10rem 10rem;
 
@@ -3657,6 +3658,7 @@
     grid-template: unset;
     grid-template: none;
     grid-template: auto 1fr auto / auto 1fr;
+    grid-template: auto 1fr auto / auto repeat(3, 1fr);
     grid-template: auto 1fr auto /
     [header-top] "a   a   a"     [header-bottom]
       [main-top] "b   b   b" 1fr [main-bottom];


### PR DESCRIPTION
Related issue: https://github.com/ryboe/CSS3/issues/194

This PR adds support for using the `repeat()` function inside `grid-template` declarations. It also adds a definition for the forward slash in both `grid-template` as well as `grid` itself. Lastly, it adds tests for these things.