### PR TITLE
Fix issue with nested calculations (value-calc)

### DIFF
--- a/CSS3.sublime-syntax
+++ b/CSS3.sublime-syntax
@@ -11664,6 +11664,11 @@ contexts:
     - include: percentage
     - include: number
     - include: arithmetic-operator
+    - match: '\('
+      push:
+        - match: '\)'
+          pop: true
+        - include: value-calc
 
   # This context matches CSS-wide keywords and functions, like "inherit",
   # "var()", and "!important". It should be included in all property contexts.


### PR DESCRIPTION
This PR fixes https://github.com/ryboe/CSS3/issues/203, which outlines an issue with recursion in calculation expressions. Specifically, something like `calc(((1)))` breaks. To see why, here's what happens when highlighting `calc(((1)))`.

- `calc(`: Matched `func-calc`, all good so far.
- `calc((`: The `(` matches the `match` directive, which includes a `value-calc` context (or a closing `)`).
- `calc(((`: The third `(` cannot match anything in the `value-calc` context, so it pops back off the context and just matches the same `match` directive as previously done, which still includes a `value-calc` context or closing `)`.
- `calc(((1`: Now the `value-calc` context matches `1`, so that's all good.
- `calc(((1)`: The `)` closes the `match` directive and we're back in the top level of `func-calc`.
- `calc(((1))`: The `)` closes the entire `func-calc` expression.
- `calc(((1)))`: Huh? There's another `)`? Panic!

So, the appropriate solution here is to make sure `value-calc` allows parenthesized expressions itself.