### PR TITLE
Add many math functions

### DIFF
--- a/CSS3.sublime-syntax
+++ b/CSS3.sublime-syntax
@@ -92,9 +92,8 @@ contexts:
 
   angle:
     - include: func-calc
-    - include: func-min
-    - include: func-max
-    - include: func-clamp
+    - include: func-math-return-angle
+    - include: func-math-return-any
     - match: '(?x)
         (?:
           ({{number}})({{angle_unit}})\b|
@@ -128,7 +127,6 @@ contexts:
     - include: func-child
     - include: func-cielab
     - include: func-cielchab
-    - include: func-clamp
     - include: func-color
     - include: func-color-adjust
     - include: func-color-adjuster-rgb
@@ -165,8 +163,6 @@ contexts:
     - include: func-linear-gradient
     - include: func-local
     - include: func-matrix
-    - include: func-max
-    - include: func-min
     - include: func-minmax
     - include: func-path
     - include: func-perspective
@@ -1018,9 +1014,7 @@ contexts:
 
   decibel:
     - include: func-calc
-    - include: func-min
-    - include: func-max
-    - include: func-clamp
+    - include: func-math-return-any
     - match: '(?x)
         (?:
           ({{number}})({{decibel_unit}})|
@@ -1673,9 +1667,8 @@ contexts:
 
   flex:
     - include: func-calc
-    - include: func-min
-    - include: func-max
-    - include: func-clamp
+    - include: func-math-return-any
+    - include: func-math-return-number
     - match: '(?x)
         (?:
           ({{number}})({{flex_unit}})\b|
@@ -1776,9 +1769,7 @@ contexts:
 
   frequency:
     - include: func-calc
-    - include: func-min
-    - include: func-max
-    - include: func-clamp
+    - include: func-math-return-any
     - match: '(?x)
         (?:
           ({{number}})({{frequency_unit}})\b|
@@ -1896,22 +1887,6 @@ contexts:
         - include: end-func
         - include: func-var
         - include: number
-
-  func-clamp:
-    - match: \b(clamp)(\()
-      captures:
-        1: support.function.clamp.css
-        2: punctuation.section.function.begin.css
-      push:
-        - meta_scope: meta.function.clamp.css
-        - match: '\('
-          push:
-            - match: '\)'
-              pop: true
-            - include: value-calc
-        - include: value-calc
-        - include: end-func
-        - include: func-var
 
   func-color:
     - match: \b(color)(\()
@@ -2439,37 +2414,35 @@ contexts:
         - include: func-var
         - include: number
 
-  func-max:
-    - match: \b(max)(\()
+  func-math-return-angle:
+    - match: \b(acos|asin|atan|atan2)(\()
       captures:
-        1: support.function.max.css
+        1: support.function.math-return-angle.css
         2: punctuation.section.function.begin.css
       push:
-        - meta_scope: meta.function.max.css
-        - match: '\('
-          push:
-            - match: '\)'
-              pop: true
-            - include: value-calc
+        - meta_scope: meta.function.math-return-angle.css
         - include: value-calc
         - include: end-func
-        - include: func-var
 
-  func-min:
-    - match: \b(min)(\()
+  func-math-return-any:
+    - match: \b(abs|clamp|hypot|max|min|mod|rem)(\()
       captures:
-        1: support.function.min.css
+        1: support.function.math-return-any.css
         2: punctuation.section.function.begin.css
       push:
-        - meta_scope: meta.function.min.css
-        - match: '\('
-          push:
-            - match: '\)'
-              pop: true
-            - include: value-calc
+        - meta_scope: meta.function.math-return-any.css
         - include: value-calc
         - include: end-func
-        - include: func-var
+
+  func-math-return-number:
+    - match: \b(cos|exp|log|pow|sign|sin|sqrt|tan)(\()
+      captures:
+        1: support.function.math-return-number.css
+        2: punctuation.section.function.begin.css
+      push:
+        - meta_scope: meta.function.math-return-number.css
+        - include: value-calc
+        - include: end-func
 
   func-minmax:
     - match: \b(minmax)(\()
@@ -2973,25 +2946,22 @@ contexts:
 
   integer:
     - include: func-calc
-    - include: func-min
-    - include: func-max
-    - include: func-clamp
+    - include: func-math-return-any
+    - include: func-math-return-number
     - match: '{{integer}}'
       scope: constant.numeric.css
 
   integer-non-negative:
     - include: func-calc
-    - include: func-min
-    - include: func-max
-    - include: func-clamp
+    - include: func-math-return-any
+    - include: func-math-return-number
     - match: '{{integer_non_neg}}'
       scope: constant.numeric.css
 
   integer-positive:
     - include: func-calc
-    - include: func-min
-    - include: func-max
-    - include: func-clamp
+    - include: func-math-return-any
+    - include: func-math-return-number
     - match: '{{integer_pos}}'
       scope: constant.numeric.css
 
@@ -3029,9 +2999,7 @@ contexts:
 
   length:
     - include: func-calc
-    - include: func-min
-    - include: func-max
-    - include: func-clamp
+    - include: func-math-return-any
     - match: '(?x)
         (?:
           ({{number}})({{length_unit}})\b|
@@ -3044,9 +3012,7 @@ contexts:
 
   length-non-negative:
     - include: func-calc
-    - include: func-min
-    - include: func-max
-    - include: func-clamp
+    - include: func-math-return-any
     - match: '(?x)
         (?:
           ({{number_non_neg}})({{length_unit}})\b|
@@ -3059,9 +3025,7 @@ contexts:
 
   length-positive:
     - include: func-calc
-    - include: func-min
-    - include: func-max
-    - include: func-clamp
+    - include: func-math-return-any
     - match: '(?x)
         (?:
           ({{number_pos}})({{length_unit}})\b|
@@ -3548,25 +3512,22 @@ contexts:
 
   number:
     - include: func-calc
-    - include: func-min
-    - include: func-max
-    - include: func-clamp
+    - include: func-math-return-any
+    - include: func-math-return-number
     - match: '{{number}}'
       scope: constant.numeric.css
 
   number-non-negative:
     - include: func-calc
-    - include: func-min
-    - include: func-max
-    - include: func-clamp
+    - include: func-math-return-any
+    - include: func-math-return-number
     - match: '{{number_non_neg}}'
       scope: constant.numeric.css
 
   number-positive:
     - include: func-calc
-    - include: func-min
-    - include: func-max
-    - include: func-clamp
+    - include: func-math-return-any
+    - include: func-math-return-number
     - match: '{{number_pos}}'
       scope: constant.numeric.css
 
@@ -3638,9 +3599,7 @@ contexts:
 
   percentage:
     - include: func-calc
-    - include: func-min
-    - include: func-max
-    - include: func-clamp
+    - include: func-math-return-any
     - match: '(?x)
         (?:
           ({{number}})({{percentage_unit}})|
@@ -3653,9 +3612,7 @@ contexts:
 
   percentage-non-negative:
     - include: func-calc
-    - include: func-min
-    - include: func-max
-    - include: func-clamp
+    - include: func-math-return-any
     - match: '(?x)
         (?:
           ({{number_non_neg}})({{percentage_unit}})|
@@ -3668,9 +3625,7 @@ contexts:
 
   percentage-zero-to-100:
     - include: func-calc
-    - include: func-min
-    - include: func-max
-    - include: func-clamp
+    - include: func-math-return-any
     - match: '(?x)
         (?:
           ({{number_zero_to_100}})({{percentage_unit}})|
@@ -11655,9 +11610,7 @@ contexts:
 
   time:
     - include: func-calc
-    - include: func-min
-    - include: func-max
-    - include: func-clamp
+    - include: func-math-return-any
     - match: '(?x)
         (?:
           ({{number}})({{time_unit}})\b|
@@ -11719,7 +11672,9 @@ contexts:
       scope: support.constant.property-value.css
 
   value-calc:
-    - include: func-sin
+    - include: func-math-return-angle
+    - include: func-math-return-any
+    - include: func-math-return-number
     - include: func-var
     - include: length
     - include: frequency

--- a/CSS3.sublime-syntax
+++ b/CSS3.sublime-syntax
@@ -163,6 +163,9 @@ contexts:
     - include: func-linear-gradient
     - include: func-local
     - include: func-matrix
+    - include: func-math-return-angle
+    - include: func-math-return-any
+    - include: func-math-return-number
     - include: func-minmax
     - include: func-path
     - include: func-perspective

--- a/CSS3.sublime-syntax
+++ b/CSS3.sublime-syntax
@@ -2639,15 +2639,6 @@ contexts:
         - include: percentage
         - include: number
 
-  func-sin:
-    - match: \b(sin)(\()
-      captures:
-        1: support.function.sin.css
-        2: punctuation.section.function.begin.css
-      push:
-        - meta_scope: meta.function.sin.css
-        - include: value-calc
-
   func-skew:
     - match: \b(skew[XY]?)(\()
       captures:

--- a/CSS3.sublime-syntax
+++ b/CSS3.sublime-syntax
@@ -2663,6 +2663,15 @@ contexts:
         - include: percentage
         - include: number
 
+  func-sin:
+    - match: \b(sin)(\()
+      captures:
+        1: support.function.sin.css
+        2: punctuation.section.function.begin.css
+      push:
+        - meta_scope: meta.function.sin.css
+        - include: value-calc
+
   func-skew:
     - match: \b(skew[XY]?)(\()
       captures:
@@ -11710,6 +11719,7 @@ contexts:
       scope: support.constant.property-value.css
 
   value-calc:
+    - include: func-sin
     - include: func-var
     - include: length
     - include: frequency

--- a/completions/functions.py
+++ b/completions/functions.py
@@ -4,7 +4,6 @@ import sublime
 # This dict maps function names to their completions. It includes pseudo-class
 # and pseudo-element functions like :nth-child() and ::attr().
 func_name_to_completions = {
-    "clamp": t.angle + t.frequency + t.length + t.number + t.percentage + t.time,
     "attr": [
         ("angle",),  # A tuple with only one string means the label is the same
         ("ch",),  # as the completion, i.e. ("foo",) is equivalent to
@@ -76,12 +75,18 @@ func_name_to_completions = {
     + t.percentage
     + t.time,
     "auto": [t.identifier, t.string],
+    "abs": t.angle + t.frequency + t.length + t.number + t.percentage + t.time,
+    "acos": t.number,
+    "asin": t.number,
+    "atan": t.number,
+    "atan2": t.angle + t.frequency + t.length + t.number + t.percentage + t.time,
     "blenda": [("hsl",), ("hwb",), ("rgb",)] + t.color + t.percentage,
     "blur": t.length,
     "calc": t.angle + t.frequency + t.length + t.number + t.percentage + t.time,
     "child": t.integer,
     "cielab": t.number,
     "cielchab": t.number,
+    "clamp": t.angle + t.frequency + t.length + t.number + t.percentage + t.time,
     "color": [("dgi-p3",), ("rec2020",), ("srgb",), t.identifier, t.string]
     + t.color
     + t.number
@@ -93,6 +98,7 @@ func_name_to_completions = {
     "conic-gradient": [("at", "at "), ("from", "from "),] + t.color_stop + t.position,
     "content": [("after",), ("before",), ("first-letter",), ("marker",), ("text",),],
     "contrast": t.number + t.percentage,
+    "cos": t.number,
     "counter": [("none",), t.identifier, t.symbols] + t.image,
     "counters": [("none",), t.identifier, t.string, t.symbols] + t.image,
     "cross-fade": t.color + t.image + t.percentage,
@@ -106,6 +112,7 @@ func_name_to_completions = {
     "drop-shadow": t.color + t.length,
     "element": [("first",), ("first-except",), ("last",), ("start",), t.identifier,],
     "ellipse-circle": [("at", "at ")] + t.shape_radius + t.position,
+    "exp": t.number,
     "fade": t.length + t.percentage,
     "filter": t.number + t.percentage,
     "fit-content": t.length + t.percentage,
@@ -119,6 +126,7 @@ func_name_to_completions = {
     "hue": t.angle,
     "hue-rotate": t.angle,
     "hwb": [("from",)] + t.color + t.angle + t.number + t.percentage,
+    "hypot": t.angle + t.frequency + t.length + t.number + t.percentage + t.time,
     "icc-color": [t.identifier] + t.icc_color + t.number,
     "image": [t.string] + t.image + t.color,
     "image-set": [t.string] + t.image + t.resolution,
@@ -128,6 +136,7 @@ func_name_to_completions = {
     "leader": [("dotted",), ("solid",), ("space",), t.string],
     "linear-gradient": [("to", "to ")] + t.angle + t.color_stop + t.side_or_corner,
     "local": [t.identifier, t.string],
+    "log": t.number,
     # "matches": [],  # TODO: matches takes a selector list as an arg. should it have completions?
     "matrix": t.number,
     "max": t.angle + t.frequency + t.length + t.number + t.percentage + t.time,
@@ -136,6 +145,7 @@ func_name_to_completions = {
     + t.flex
     + t.length
     + t.percentage,
+    "mod": t.angle + t.frequency + t.length + t.number + t.percentage + t.time,
     # "not": [],      # TODO: not takes a selector list as an arg. should it have completions?
     "nth-child": [("of", "of ")],
     "nth-last-child": [("of", "of ")],
@@ -143,12 +153,14 @@ func_name_to_completions = {
     "path": [t.string] + t.fill_rule,
     "perspective": t.length,
     "polygon": t.fill_rule + t.shape_arg,
+    "pow": t.number,
     "radial-gradient": [("at", "at "), ("circle",), ("ellipse",),]
     + t.color_stop
     + t.position
     + t.size,
     "ray": [("contain",)] + t.angle + t.size,
     "red-green-blue-alpha-a": t.number + t.percentage,
+    "rem": t.angle + t.frequency + t.length + t.number + t.percentage + t.time,
     "repeat": [("auto-fill",), t.identifier, t.line_names,]
     + t.integer
     + t.track_size,
@@ -157,10 +169,13 @@ func_name_to_completions = {
     "running": [t.identifier],
     # "select": [],   # TODO: select takes a selector list as an arg. should it have completions?
     "scale": t.number,
+    "sign": t.number,
+    "sin": t.number,
     "skew": t.angle,
     # "slotted": [],  # TODO: slotted takes a selector list as an arg. should it have completions?
     "snap-block": [("end",), ("near",), ("start",)] + t.length,
     "snap-inline": [("left",), ("near",), ("right",)] + t.length,
+    "sqrt": t.number,
     "steps": [("start",), ("end",)] + t.integer,
     "string": [("first",), ("first-except",), ("last",), ("start",), t.identifier],
     "swash-styleset-stylistic-ornaments-character-variant-annotation": [t.identifier]
@@ -174,6 +189,7 @@ func_name_to_completions = {
         t.string,
     ]
     + t.image,
+    "tan": t.number,
     "target-counters": [t.string, t.url] + t.counter_style,
     "target-text": [
         ("after",),

--- a/test/property-list.css
+++ b/test/property-list.css
@@ -4088,6 +4088,10 @@
     height: min(max(100%), fit-content);
     height: clamp(10px, 5vmin, 30px);
     height: clamp(10px, clamp(5vmin, 20%), 20vw);
+    height: abs(10px, 5px - 5%);
+    height: hypot(10px, 5vmin, 30px);
+    height: mod(50px, 15rem);
+    height: rem(50px, 15rem);
 
     hyphens: initial;
     hyphens: inherit;
@@ -4283,6 +4287,21 @@
     line-height: 0;
     line-height: 100%;
     line-height: 100px;
+    line-height: abs(-1.1);
+    line-height: clamp(1.1, 2 - 4, 1.3);
+    line-height: hypot(1, 2, 3);
+    line-height: max(1, 2);
+    line-height: min(1, 2);
+    line-height: mod(5, 2);
+    line-height: rem(5, 2);
+    line-height: cos(5turn);
+    line-height: exp(2);
+    line-height: log(2);
+    line-height: pow(1.1, 2);
+    line-height: sign(7);
+    line-height: sin(5deg);
+    line-height: sqrt(1.2 + .1);
+    line-height: tan(5deg + 10deg);
 
     line-snap: initial;
     line-snap: inherit;
@@ -5434,6 +5453,17 @@
     rest-before: medium;
     rest-before: x-strong;
     rest-before: strong;
+
+    rotate: initial;
+    rotate: inherit;
+    rotate: unset;
+    rotate: 180deg;
+    rotate: 45deg;
+    rotate: -45deg;
+    rotate: acos(1);
+    rotate: asin(1 - .1);
+    rotate: atan(1 / 2);
+    rotate: atan2(2rem, 5rem);
 
     rotation: initial;
     rotation: inherit;


### PR DESCRIPTION
This PR adds all functions from https://github.com/ryboe/CSS3/issues/205 except `round()`, since that one specifically accepts a keyword for its first argument. Probably I'll handle that one at some point in the future.

I've opted to restructure `min`, `max` and `clamp` slightly here to reduce on repetition. These CSS functions differ only really in their return value; the system already didn't check for the units inside calculations, e.g. you'd never have an angle in a `width: ` calculation, but  `width: calc(10deg)` highlights just fine.

However caring about the return value means that e.g. `width: sin(10deg)` is _not_ highlighted (since `sin()` returns a number, not a length) but `line-height: sin(10deg)` does highlight. `min()`, `max()` and `clamp()` fall in the bucket of functions that can return anything, and their return value depends on their arguments.