### PR TITLE
Add mathematical constants

### DIFF
--- a/CSS3.sublime-syntax
+++ b/CSS3.sublime-syntax
@@ -681,6 +681,10 @@ contexts:
     - match: '\b(?:padding-box|content-box|border-box){{b}}'
       scope: support.constant.property-value.css
 
+  calc-keyword:
+    - match: '\b(?:NaN|infinity|pi|e){{b}}'
+      scope: support.constant.property-value.css
+
   caret-shape:
     - match: '\b(?:underscore|block|bar|auto){{b}}'
       scope: support.constant.property-value.css
@@ -11685,6 +11689,7 @@ contexts:
     - include: func-math-return-any
     - include: func-math-return-number
     - include: func-var
+    - include: calc-keyword
     - include: length
     - include: frequency
     - include: angle

--- a/test/property-list.css
+++ b/test/property-list.css
@@ -4092,7 +4092,7 @@
     height: hypot(10px, 5vmin, 30px);
     height: mod(50px, 15rem);
     height: rem(50px, 15rem);
-    height: min(e, pi, infinity, NaN);
+    height: calc(min(e, pi, infinity, NaN) * 1px);
 
     hyphens: initial;
     hyphens: inherit;

--- a/test/property-list.css
+++ b/test/property-list.css
@@ -4092,6 +4092,7 @@
     height: hypot(10px, 5vmin, 30px);
     height: mod(50px, 15rem);
     height: rem(50px, 15rem);
+    height: min(e, pi, infinity, NaN);
 
     hyphens: initial;
     hyphens: inherit;


### PR DESCRIPTION
Adds `infinity`, `NaN`, `pi` and `e` as mathematical constants, and thereby resolves https://github.com/ryboe/CSS3/issues/219.