### PR TITLE
fix dash escape

### DIFF
--- a/CSS3.sublime-syntax
+++ b/CSS3.sublime-syntax
@@ -1002,7 +1002,7 @@ contexts:
         - meta_scope: meta.declaration-list.css
         - match: '(?=})'
           pop: true
-        - match: '(?=@media|@supports|@layer|@container)|(?=[\w.:#\[*-&][^;}]*\{)'
+        - match: '(?=@media|@supports|@layer|@container)|(?=[\w.:#\[*\-&][^;}]*\{)'
           push:
             - match: '(?=})'
               scope: punctuation.section.declaration-list.end.css
@@ -10890,7 +10890,7 @@ contexts:
   #     property2: value2;
   # }
   rule:
-    - match: '(?=[\w.:#\[*-&])'
+    - match: '(?=[\w.:#\[*\-&])'
       push:
         - meta_scope: meta.rule.css
         - match: '}'
@@ -10916,7 +10916,7 @@ contexts:
   selector:
     # This match applies a single meta.selector.css scope to a comma-separated
     # list of selectors, so that they appear as one entry in the Symbol List.
-    - match: '(?=[\w.:#\[*-&])'
+    - match: '(?=[\w.:#\[*\-&])'
       push:
         - meta_content_scope: meta.selector.css
         - match: '(?={)'


### PR DESCRIPTION
Fixes: https://github.com/ryboe/CSS3/issues/224

Inside of a character range, escape `-` to be treated literally instead of as `[a-z]` range notation in Oniguruma