### PR TITLE
Fix semicolon-terminated at layer statements

### DIFF
--- a/CSS3.sublime-syntax
+++ b/CSS3.sublime-syntax
@@ -486,6 +486,9 @@ contexts:
         - match: '}'
           scope: punctuation.section.at-media.end.css
           pop: true
+        - match: ';'
+          scope: punctuation.terminator.layer.css
+          pop: true
         - match: '{'
           scope: punctuation.section.at-media.begin.css
           push:
@@ -495,6 +498,8 @@ contexts:
             - include: nestable-at-rules
             - include: properties
             - include: rule
+        - include: identifier
+    - include: stray-semicolon
     - include: stray-brace
 
   at-namespace:

--- a/test/at-layer.css
+++ b/test/at-layer.css
@@ -1,3 +1,5 @@
+@layer test.bar, test;
+
 @layer test {
   foo {
     color: red;


### PR DESCRIPTION
This pull request resolves https://github.com/ryboe/CSS3/issues/227.

It introduces proper highlighting for `@layer` statements (as opposed to rules), for example, `@layer foo, bar, baz.qux;`.