### PR TITLE
Add accent-color property

### DIFF
--- a/CSS3.sublime-syntax
+++ b/CSS3.sublime-syntax
@@ -4077,6 +4077,19 @@ contexts:
     - include: string
     - include: identifier
 
+  # CSS Basic User Interface Module Level 4
+  property-color:
+    - match: \b(accent-color)\s*(:)
+      captures:
+        1: support.type.property-name.css
+        2: punctuation.separator.key-value.css
+      push:
+        - meta_content_scope: meta.property-value.accent-color.css
+        - include: end-value
+        - include: value-css-wide
+        - include: color
+    - include: stray-paren-or-semicolon
+
   # align-content is defined in two specs:
   #     CSS Box Alignment Module Level 3
   #     CSS Flexible Box Layout Module Level 1 (subset of Box Alignment Level 3)

--- a/CSS3.sublime-syntax
+++ b/CSS3.sublime-syntax
@@ -3654,6 +3654,7 @@ contexts:
 
     # Properties with names that are two or more words are given a higher
     # precedence because they are less likely to mismatch.
+    - include: property-accent-color
     - include: property-align-content
     - include: property-align-items
     - include: property-align-self
@@ -4078,7 +4079,7 @@ contexts:
     - include: identifier
 
   # CSS Basic User Interface Module Level 4
-  property-color:
+  property-accent-color:
     - match: \b(accent-color)\s*(:)
       captures:
         1: support.type.property-name.css

--- a/test/property-list.css
+++ b/test/property-list.css
@@ -1,4 +1,27 @@
 * {
+    accent-color: initial;
+    accent-color: inherit;
+    accent-color: unset;
+    accent-color: currentcolor;
+    accent-color: rgb(178, 34, 34);
+    accent-color: rgb(10%, 0%, 20%);
+    accent-color: rgba(255, 255, 255, 1.0);
+    accent-color: rgba(255, 255, 255, 0.12124);
+    accent-color: #aaaaaa;
+    accent-color: #aaa;
+    accent-color: #111111;
+    accent-color: #fff;
+    accent-color: hsl(360, 100%, 25%);
+    accent-color: hsl(1, 0%, 25%);
+    accent-color: hsl(120deg, 44%, 50%);
+    accent-color: hsla(1, 0%, 25%, 1.0);
+    accent-color: firebrick;
+    accent-color: rebeccapurple;
+    accent-color: hwb(120deg, 44%, 50%);
+    accent-color: color(red s(- 10%) s(- 10%));
+    accent-color: color(contrast(25%));
+    accent-color: device-cmyk(0, 81%, 81%, 30%);
+
     align-content: initial;
     align-content: inherit;
     align-content: unset;


### PR DESCRIPTION
Resolves https://github.com/ryboe/CSS3/issues/226

This PR adds the `accent-color` property. Syntax is the same as any other color property, so nothing too complicated.