### PR TITLE
Add missing <basic-shape> functions; path(), rect() and xywh()

### DIFF
--- a/CSS3.sublime-syntax
+++ b/CSS3.sublime-syntax
@@ -631,6 +631,9 @@ contexts:
     - include: func-inset
     - include: func-ellipse-circle
     - include: func-polygon
+    - include: func-path
+    - include: func-rect
+    - include: func-xywh
 
   blend-mode:
     - match: '(?x)
@@ -2557,6 +2560,22 @@ contexts:
         - include: angle
         - include: size
 
+  func-rect:
+    - match: \b(rect)(\()
+      captures:
+        1: support.function.rect.css
+        2: punctuation.section.function.begin.css
+      push:
+        - meta_scope: meta.function.rect.css
+        - include: end-func
+        - include: func-var
+        - match: '\bround{{b}}'
+          scope: support.constant.property-value.css
+        - include: shape-arg
+        - match: '\/'
+          scope: keyword.operator.arithmetic.css
+
+
   func-red-green-blue-alpha-a:
     - match: \b(red|green|blue|alpha|a)(\()
       captures:
@@ -2901,6 +2920,21 @@ contexts:
         - include: func-var
         - include: percentage
         - include: color-adjuster-operator
+
+  func-xywh:
+    - match: \b(xywh)(\()
+      captures:
+        1: support.function.xywh.css
+        2: punctuation.section.function.begin.css
+      push:
+        - meta_scope: meta.function.xywh.css
+        - include: end-func
+        - include: func-var
+        - match: '\bround{{b}}'
+          scope: support.constant.property-value.css
+        - include: shape-arg
+        - match: '\/'
+          scope: keyword.operator.arithmetic.css
 
   generic-voice:
     - match: '\b(?:young|old|neutral|male|female|child){{b}}'

--- a/test/property-list.css
+++ b/test/property-list.css
@@ -2086,13 +2086,13 @@
                   122px 57px, 184px 73px, 198px 105px, 199px 150px,
                   145px 159px, 155px 139px, 126px 120px, 112px 138px,
                   80px 128px, 39px 126px, 24px 104px);
-
+    clip-path: path("M0 0L1 1Q1,2-3-3Zm5 5.6.6.6Z");
+    clip-path: rect(5px 5px 160px 20% 145px round 20%);
     clip-rule: initial;
     clip-rule: inherit;
     clip-rule: unset;
     clip-rule: nonzero;
     clip-rule:evenodd  ;
-
 
     /* out of range 0-100% */
 

--- a/test/property-list.css
+++ b/test/property-list.css
@@ -2086,13 +2086,16 @@
                   122px 57px, 184px 73px, 198px 105px, 199px 150px,
                   145px 159px, 155px 139px, 126px 120px, 112px 138px,
                   80px 128px, 39px 126px, 24px 104px);
+
     clip-path: path("M0 0L1 1Q1,2-3-3Zm5 5.6.6.6Z");
     clip-path: rect(5px 5px 160px 20% 145px round 20%);
+    clip-path: xywh(-10% -5px 0 100px round 10% 0);
     clip-rule: initial;
     clip-rule: inherit;
     clip-rule: unset;
     clip-rule: nonzero;
     clip-rule:evenodd  ;
+
 
     /* out of range 0-100% */
 


### PR DESCRIPTION
Resolves #230. See also [`<basic-shape>` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/basic-shape).